### PR TITLE
[EVENT] 이벤트 게시글 목록 조회/상세 조회 기능 추가

### DIFF
--- a/src/main/java/com/swcamp9th/bangflixbackend/domain/eventPost/controller/EventPostController.java
+++ b/src/main/java/com/swcamp9th/bangflixbackend/domain/eventPost/controller/EventPostController.java
@@ -1,7 +1,9 @@
 package com.swcamp9th.bangflixbackend.domain.eventPost.controller;
 
 import com.swcamp9th.bangflixbackend.common.ResponseMessage;
+import com.swcamp9th.bangflixbackend.domain.eventPost.dto.EventListDTO;
 import com.swcamp9th.bangflixbackend.domain.eventPost.dto.EventPostCreateDTO;
+import com.swcamp9th.bangflixbackend.domain.eventPost.dto.EventPostDTO;
 import com.swcamp9th.bangflixbackend.domain.eventPost.dto.EventPostUpdateDTO;
 import com.swcamp9th.bangflixbackend.domain.eventPost.service.EventPostService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -16,6 +18,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 @RestController("eventPostController")
 @Slf4j
@@ -68,8 +71,21 @@ public class EventPostController {
         return ResponseEntity.ok(new ResponseMessage<>(200, "게시글 삭제 성공", null));
     }
 
-    /* 이벤트 게시글 목록 조회 */
+    /* 할인테마/신규테마 이벤트 게시글 목록 조회 */
+    @GetMapping("")
+    @Operation(summary = "이벤트 게시글 목록 조회 API (해당 테마 정보 조회)")
+    public ResponseEntity<ResponseMessage<List<EventListDTO>>> getEventList() {
 
+        List<EventListDTO> categoryAndEventList = eventPostService.getEventList();
+        return ResponseEntity.ok(new ResponseMessage<>(200, "이벤트 게시글 목록 조회 성공", categoryAndEventList));
+    }
 
     /* 이벤트 게시글 상세 조회 */
+    @GetMapping("/post/{eventPostCode}")
+    @Operation(summary = "이벤트 게시글 상세 조회 API")
+    public ResponseEntity<ResponseMessage<EventPostDTO>> getEventPost(@PathVariable int eventPostCode) {
+
+        EventPostDTO eventPost = eventPostService.findEventByCode(eventPostCode);
+        return ResponseEntity.ok(new ResponseMessage<>(200, "이벤트 게시글 상세 조회 성공", eventPost));
+    }
 }

--- a/src/main/java/com/swcamp9th/bangflixbackend/domain/eventPost/dto/EventListDTO.java
+++ b/src/main/java/com/swcamp9th/bangflixbackend/domain/eventPost/dto/EventListDTO.java
@@ -1,0 +1,16 @@
+package com.swcamp9th.bangflixbackend.domain.eventPost.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@ToString
+public class EventListDTO {
+
+    String category;
+    List<EventPostDTO> eventList;
+}

--- a/src/main/java/com/swcamp9th/bangflixbackend/domain/eventPost/dto/EventPostDTO.java
+++ b/src/main/java/com/swcamp9th/bangflixbackend/domain/eventPost/dto/EventPostDTO.java
@@ -18,9 +18,11 @@ public class EventPostDTO {
     private String title;                   // 제목
     private String content;                 // 게시글 내용
     private String category;                // 카테고리(할인테마/신규테마)
-    private Integer themeCode;              // 테마 코드
     private Integer memberCode;             // 회원 코드(작성자)
 
     // 첨부파일 URL 리스트
     private List<String> imageUrls;         // 첨부파일들
+
+    // 이벤트 해당 테마
+    private EventThemeDTO eventTheme;
 }

--- a/src/main/java/com/swcamp9th/bangflixbackend/domain/eventPost/dto/EventThemeDTO.java
+++ b/src/main/java/com/swcamp9th/bangflixbackend/domain/eventPost/dto/EventThemeDTO.java
@@ -1,0 +1,16 @@
+package com.swcamp9th.bangflixbackend.domain.eventPost.dto;
+
+import lombok.*;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@ToString
+public class EventThemeDTO {
+
+    private Integer themeCode;
+    private String name;
+    private String posterImage;
+    private Integer storeCode;
+}

--- a/src/main/java/com/swcamp9th/bangflixbackend/domain/eventPost/entity/EventPost.java
+++ b/src/main/java/com/swcamp9th/bangflixbackend/domain/eventPost/entity/EventPost.java
@@ -38,7 +38,7 @@ public class EventPost {
     private String category;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "theme_code")
+    @JoinColumn(name = "theme_code", nullable = false)
     private Theme theme;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/swcamp9th/bangflixbackend/domain/eventPost/repository/EventFileRepository.java
+++ b/src/main/java/com/swcamp9th/bangflixbackend/domain/eventPost/repository/EventFileRepository.java
@@ -1,9 +1,14 @@
 package com.swcamp9th.bangflixbackend.domain.eventPost.repository;
 
 import com.swcamp9th.bangflixbackend.domain.eventPost.entity.EventFile;
+import com.swcamp9th.bangflixbackend.domain.eventPost.entity.EventPost;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository("eventFileRepository")
 public interface EventFileRepository extends JpaRepository<EventFile, Integer> {
+
+    List<EventFile> findByEventPost(EventPost foundEvent);
 }

--- a/src/main/java/com/swcamp9th/bangflixbackend/domain/eventPost/repository/EventPostRepository.java
+++ b/src/main/java/com/swcamp9th/bangflixbackend/domain/eventPost/repository/EventPostRepository.java
@@ -2,8 +2,15 @@ package com.swcamp9th.bangflixbackend.domain.eventPost.repository;
 
 import com.swcamp9th.bangflixbackend.domain.eventPost.entity.EventPost;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository("eventPostRepository")
 public interface EventPostRepository extends JpaRepository<EventPost, Integer> {
+
+//    @Query("SELECT p FROM EventPost p JOIN FETCH p.theme " +
+//            "WHERE p.active = true AND p.category = :category ORDER BY p.createdAt DESC")
+    List<EventPost> findTop5ByActiveTrueAndCategoryEqualsOrderByCreatedAtDesc(String category);
 }

--- a/src/main/java/com/swcamp9th/bangflixbackend/domain/eventPost/service/EventPostService.java
+++ b/src/main/java/com/swcamp9th/bangflixbackend/domain/eventPost/service/EventPostService.java
@@ -1,6 +1,8 @@
 package com.swcamp9th.bangflixbackend.domain.eventPost.service;
 
+import com.swcamp9th.bangflixbackend.domain.eventPost.dto.EventListDTO;
 import com.swcamp9th.bangflixbackend.domain.eventPost.dto.EventPostCreateDTO;
+import com.swcamp9th.bangflixbackend.domain.eventPost.dto.EventPostDTO;
 import com.swcamp9th.bangflixbackend.domain.eventPost.dto.EventPostUpdateDTO;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -16,4 +18,7 @@ public interface EventPostService {
 
     void deleteEventPost(String loginId, int eventPostCode);
 
+    List<EventListDTO> getEventList();
+
+    EventPostDTO findEventByCode(int eventPostCode);
 }

--- a/src/main/java/com/swcamp9th/bangflixbackend/domain/theme/entity/Theme.java
+++ b/src/main/java/com/swcamp9th/bangflixbackend/domain/theme/entity/Theme.java
@@ -1,8 +1,11 @@
 package com.swcamp9th.bangflixbackend.domain.theme.entity;
 
+import com.swcamp9th.bangflixbackend.domain.eventPost.entity.EventPost;
 import com.swcamp9th.bangflixbackend.domain.store.entity.Store;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
+import java.util.List;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -51,7 +54,6 @@ public class Theme {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "store_code", nullable = false)
     private Store store;
-
 
 }
 


### PR DESCRIPTION
### 요약
- 이벤트 게시글 목록 조회/상세 조회 기능 추가

### 관련 이슈
- #70 #84 

### 완료 사항
- 이벤트 게시글 목록 조회(해당 테마 정보, 카테고리별 최신순 상위 5개 조회) 기능 추가했습니다.
- 이벤트 게시글 상세 조회 기능 추가했습니다.

### 필요 테스트
- 완료

### 체크리스트
- [x] 닌자코드로 작성하지 않았나요?
- [x] 작성 코드에 대한 셀프체크를 하셨나요?
- [x] 이해가 어려운 부분에 대한 주석이나 설명이 잘 작성됐나요?
- [x] 공유된 이슈 사항 및 요구사항을 만족하였나요?
- [x] 테스트코드가 모두 잘 작동하나요?
